### PR TITLE
Provide support for base interfaces/classes.

### DIFF
--- a/adt4j-examples/src/main/java/com/github/sviperll/adt4j/examples/BaseOptionalSupport.java
+++ b/adt4j-examples/src/main/java/com/github/sviperll/adt4j/examples/BaseOptionalSupport.java
@@ -1,0 +1,53 @@
+package com.github.sviperll.adt4j.examples;
+
+public abstract class BaseOptionalSupport<T> {
+
+  //  Provide an abstract accept method which will be 'implemented' by the value object.
+  abstract <R, E extends Exception> R accept(BaseOptionalVisitor<T,R,E> visitor) throws E;
+
+  // Implement the flatMap operation for our BaseOptional value, without having to double wrap on top of the class.
+  public <U> BaseOptional<U> flatMap(final Function<T, BaseOptional<U>> function) {
+    return accept(new BaseOptionalVisitor<T, BaseOptional<U>, RuntimeException>() {
+      @Override
+      public BaseOptional<U> missing() {
+        return BaseOptional.missing();
+      }
+
+      @Override
+      public BaseOptional<U> present(T value) {
+        return function.apply(value);
+      }
+    });
+  }
+
+  // Implement the map operation for our BaseOptional value, without having to double wrap on top of the class.
+  public <U> BaseOptional<U> map(final Function<T, U> function) {
+    return accept(new BaseOptionalVisitor<T, BaseOptional<U>, RuntimeException>() {
+      @Override
+      public BaseOptional<U> missing() {
+        return BaseOptional.missing();
+      }
+
+      @Override
+      public BaseOptional<U> present(T value) {
+        return BaseOptional.present(function.apply(value));
+      }
+    });
+  }
+
+  public String toString(BaseOptional<String> optional) {
+    return optional.accept(new BaseOptionalVisitor<String, String, RuntimeException>() {
+      @Override
+      public String missing() throws RuntimeException {
+        return "BaseOptional.missing()";
+      }
+
+      @Override
+      public String present(String value) throws RuntimeException {
+        return "BaseOptional.present(\"" + value + "\")";
+      }
+    });
+  }
+
+
+}

--- a/adt4j-examples/src/main/java/com/github/sviperll/adt4j/examples/BaseOptionalVisitor.java
+++ b/adt4j-examples/src/main/java/com/github/sviperll/adt4j/examples/BaseOptionalVisitor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014, Victor Nazarov <asviraspossible@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation and/or
+ *     other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ *  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.sviperll.adt4j.examples;
+
+import com.github.sviperll.adt4j.GenerateValueClassForVisitor;
+import com.github.sviperll.adt4j.Getter;
+import com.github.sviperll.meta.Visitor;
+
+@GenerateValueClassForVisitor(baseClass = "com.github.sviperll.adt4j.examples.BaseOptionalSupport<T>")
+@Visitor(resultVariableName = "R", exceptionVariableName = "E")
+public interface BaseOptionalVisitor<T, R, E extends Exception> {
+    R missing() throws E;
+    R present(@Getter(name = "getValue") T value) throws E;
+}

--- a/adt4j-examples/src/main/java/com/github/sviperll/adt4j/examples/Main.java
+++ b/adt4j-examples/src/main/java/com/github/sviperll/adt4j/examples/Main.java
@@ -32,7 +32,7 @@ package com.github.sviperll.adt4j.examples;
 import java.io.IOException;
 
 public class Main {
-    public static void main(String[] args) throws IOException, ClassNotFoundException {
+    public static void main(final String[] args) throws IOException, ClassNotFoundException {
         Tree<String> tree = Tree.<String>node(List.<Tree<String>>cons(Tree.<String>leaf("aaa"), List.<Tree<String>>nil()));
         System.out.println(tree);
         final GADT<Integer> a = GADT.number(1);
@@ -59,6 +59,18 @@ public class Main {
         System.out.println("lookup2(\"b\") -> " + toString(lookup2("b")));
         System.out.println("lookup2(\"c\") -> " + toString(lookup2("c")));
         System.out.println("lookup2(\"d\") -> " + toString(lookup2("d")));
+        System.out.println("lookup3(\"a\") -> " + lookup3("a").toString());
+        System.out.println("lookup3(\"b\") -> " + lookup3("b").toString());
+        System.out.println("lookup3(\"c\") -> " + lookup3("c").toString());
+        System.out.println("lookup3(\"d\") -> " + lookup3("d").toString());
+
+        final Function<String, Integer> lengthOfStringFunction = new Function<String, Integer>() {
+            @Override
+            public Integer apply(String argument) {
+                return argument.length();
+            }
+        };
+        System.out.println("length map lookup3(\"a\") -> " + lookup3("a").map(lengthOfStringFunction).toString());
 
         String aa = "begin";
         Optional<String> oa = Optional.present(aa + "ning");
@@ -132,6 +144,29 @@ public class Main {
             @Override
             public Optional<String> apply(String name2) {
                 return lookup(name2);
+            }
+        });
+    }
+
+    public static BaseOptional<String> baseLookup(String name) {
+        if ("a".equals(name))
+            return BaseOptional.present("b");
+        if ("b".equals(name))
+            return BaseOptional.present("c");
+        if ("c".equals(name))
+            return BaseOptional.present("d");
+        return BaseOptional.missing();
+    }
+
+    public static BaseOptional<String> lookup3(String name1) {
+        // Using Java 8 syntax:
+        //
+        //     return lookup3(name1).flatMap(Main::lookup)
+        //
+        return baseLookup(name1).flatMap(new Function<String, BaseOptional<String>>() {
+            @Override
+            public BaseOptional<String> apply(String name2) {
+                return baseLookup(name2);
             }
         });
     }

--- a/adt4j/src/main/java/com/github/sviperll/adt4j/GenerateValueClassForVisitor.java
+++ b/adt4j/src/main/java/com/github/sviperll/adt4j/GenerateValueClassForVisitor.java
@@ -81,6 +81,26 @@ public @interface GenerateValueClassForVisitor {
     String className() default ":auto";
 
     /**
+     * Name of an interface for value classes to implement.
+     * <p>
+     * You can leave the baseInterface parameter out.
+     * Generated classes will implement this interface, allowing the developer to work with abstractions,
+     * and make use of Java 8 default methods.
+     * @return Class name of marker interface.
+     */
+    String baseInterface() default "";
+
+    /**
+     * Name of an class for value classes to extend.
+     * <p>
+     * You can leave the baseClass parameter out.
+     * Generated classes will extends this interface, allowing the developer to work with abstractions,
+     * and make use of Java 8 default methods.
+     * @return Class name of marker interface.
+     */
+    String baseClass() default "";
+
+    /**
      * Java's access for generated class.
      * <p>
      * Public or package-private.

--- a/adt4j/src/main/java/com/github/sviperll/adt4j/GenerateValueClassForVisitorProcessor.java
+++ b/adt4j/src/main/java/com/github/sviperll/adt4j/GenerateValueClassForVisitorProcessor.java
@@ -98,7 +98,7 @@ public class GenerateValueClassForVisitorProcessor extends AbstractProcessor {
                 GenerateValueClassForVisitor generateAnnotation = element.getAnnotation(GenerateValueClassForVisitor.class);
                 JCodeModelJavaxLangModelAdapter adapter = new JCodeModelJavaxLangModelAdapter(jCodeModel, processingEnv.getElementUtils());
                 JDefinedClass visitorModel = adapter.getClassWithErrorTypes(element);
-                JDefinedClass valueClass = ValueClassModelFactory.createValueClass(visitorModel, visitorAnnotation, generateAnnotation);
+                JDefinedClass valueClass = ValueClassModelFactory.createValueClass(jCodeModel, visitorModel, visitorAnnotation, generateAnnotation);
                 if (jCodeModel.buildsErrorTypeRefs()) {
                     remainingElements.add(element.getQualifiedName().toString());
                 } else {

--- a/adt4j/src/main/java/com/github/sviperll/adt4j/model/ValueClassModel.java
+++ b/adt4j/src/main/java/com/github/sviperll/adt4j/model/ValueClassModel.java
@@ -29,12 +29,12 @@
  */
 package com.github.sviperll.adt4j.model;
 
+import com.github.sviperll.Caching;
 import com.github.sviperll.adt4j.model.util.Serialization;
 import com.github.sviperll.adt4j.model.util.Source;
 import com.github.sviperll.adt4j.model.util.Types;
 import com.github.sviperll.adt4j.model.util.ValueVisitorInterfaceModel;
 import com.github.sviperll.adt4j.model.util.VariableNameSource;
-import com.github.sviperll.Caching;
 import com.github.sviperll.meta.SourceCodeValidationException;
 import com.helger.jcodemodel.AbstractJClass;
 import com.helger.jcodemodel.AbstractJType;
@@ -55,14 +55,15 @@ import com.helger.jcodemodel.JMod;
 import com.helger.jcodemodel.JOp;
 import com.helger.jcodemodel.JTypeVar;
 import com.helger.jcodemodel.JVar;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 class ValueClassModel {
     private final JDefinedClass valueClass;


### PR DESCRIPTION
This allows for providing abstractions over common disparate ADT values, and offering a simple way of
providing extension methods directly on the generated value classes.

I'm not 100% happy with using `String`'s to refer to the `baseClass` or `baseInterface` attributes ( you can see the example in the `BaseOptionalVisitor.java` file, but it's been a _long_ since I've use JCodeModel or written an annotation processor so not sure if it's possible to refer to the `.class` objects directly here ( and fall into the type mirrors API ) so maybe you have some better ideas/thoughts.

Basically, this gives ADT4j the ability to declare a base/marker interface for the generated value class, which would allow for some common abstractions to be implemented. As part of this change the generic declaration for the exception type is moved down to the `accept` method, otherwise the base class can't provide an generified instance of of a visitor.

All tests as they are continue to pass.
